### PR TITLE
Qualify function names with their module name

### DIFF
--- a/src/obelix/Processor.h
+++ b/src/obelix/Processor.h
@@ -255,14 +255,14 @@ ErrorOrNode process_tree(std::shared_ptr<SyntaxNode> const& tree, Context& ctx, 
         }
         switch (func_decl->node_type()) {
         case SyntaxNodeType::FunctionDecl:
-            ret = std::make_shared<FunctionDecl>(func_decl->token(), identifier, parameters);
+            ret = std::make_shared<FunctionDecl>(func_decl->token(), func_decl->module(), identifier, parameters);
             break;
         case SyntaxNodeType::NativeFunctionDecl:
-            ret = std::make_shared<NativeFunctionDecl>(func_decl->token(), identifier, parameters,
+            ret = std::make_shared<NativeFunctionDecl>(func_decl->token(), func_decl->module(), identifier, parameters,
                 std::dynamic_pointer_cast<NativeFunctionDecl>(func_decl)->native_function_name());
             break;
         case SyntaxNodeType::IntrinsicDecl:
-            ret = std::make_shared<IntrinsicDecl>(func_decl->token(), identifier, parameters);
+            ret = std::make_shared<IntrinsicDecl>(func_decl->token(), func_decl->module(), identifier, parameters);
             break;
         default:
             fatal("Unreachable");
@@ -282,13 +282,13 @@ ErrorOrNode process_tree(std::shared_ptr<SyntaxNode> const& tree, Context& ctx, 
         }
         switch (func_decl->node_type()) {
         case SyntaxNodeType::BoundFunctionDecl:
-            ret = std::make_shared<BoundFunctionDecl>(func_decl, identifier, parameters);
+            ret = std::make_shared<BoundFunctionDecl>(func_decl, func_decl->module(), identifier, parameters);
             break;
         case SyntaxNodeType::BoundNativeFunctionDecl:
-            ret = std::make_shared<BoundNativeFunctionDecl>(std::dynamic_pointer_cast<BoundNativeFunctionDecl>(func_decl), identifier, parameters);
+            ret = std::make_shared<BoundNativeFunctionDecl>(std::dynamic_pointer_cast<BoundNativeFunctionDecl>(func_decl), func_decl->module(), identifier, parameters);
             break;
         case SyntaxNodeType::BoundIntrinsicDecl:
-            ret = std::make_shared<BoundIntrinsicDecl>(func_decl, identifier, parameters);
+            ret = std::make_shared<BoundIntrinsicDecl>(func_decl, func_decl->module(), identifier, parameters);
             break;
         default:
             fatal("Unreachable");

--- a/src/obelix/ResolveOperators.cpp
+++ b/src/obelix/ResolveOperators.cpp
@@ -49,7 +49,7 @@ NODE_PROCESSOR(BoundUnaryExpression)
         break;
     }
     }
-    return TRY(process(make_node<BoundIntrinsicCall>(expr->token(), decl, BoundExpressions { operand }, intrinsic), ctx, result));
+    return TRY(process(std::make_shared<BoundIntrinsicCall>(expr->token(), decl, BoundExpressions { operand }, intrinsic), ctx, result));
 }
 
 NODE_PROCESSOR(BoundBinaryExpression)
@@ -70,20 +70,20 @@ NODE_PROCESSOR(BoundBinaryExpression)
             auto offset_val = offset_literal->value();
             if (expr->op() == BinaryOperator::Subtract)
                 offset_val *= -1;
-            offset = make_node<BoundIntLiteral>(rhs->token(), target_type->size() * offset_val);
+            offset = std::make_shared<BoundIntLiteral>(rhs->token(), target_type->size() * offset_val);
         } else {
             offset = rhs;
             if (expr->op() == BinaryOperator::Subtract)
-                offset = make_node<BoundUnaryExpression>(expr->token(), offset, UnaryOperator::Negate, expr->type());
-            auto size = make_node<BoundIntLiteral>(rhs->token(), target_type->size());
-            offset = TRY_AND_CAST(BoundExpression, make_node<BoundBinaryExpression>(expr->token(), size, BinaryOperator::Multiply, offset, ObjectType::get("u64")), ctx);
+                offset = std::make_shared<BoundUnaryExpression>(expr->token(), offset, UnaryOperator::Negate, expr->type());
+            auto size = std::make_shared<BoundIntLiteral>(rhs->token(), target_type->size());
+            offset = TRY_AND_CAST(BoundExpression, std::make_shared<BoundBinaryExpression>(expr->token(), size, BinaryOperator::Multiply, offset, ObjectType::get("u64")), ctx);
         }
-        auto ident = make_node<BoundIdentifier>(Token {}, BinaryOperator_name(expr->op()), lhs->type());
+        auto ident = std::make_shared<BoundIdentifier>(Token {}, BinaryOperator_name(expr->op()), lhs->type());
         BoundIdentifiers params;
-        params.push_back(make_node<BoundIdentifier>(Token {}, "ptr", lhs->type()));
-        params.push_back(make_node<BoundIdentifier>(Token {}, "offset", ObjectType::get("s32")));
-        auto decl = make_node<BoundIntrinsicDecl>(ident, params);
-        return TRY(process(make_node<BoundIntrinsicCall>(expr->token(), decl, BoundExpressions { lhs, offset }, IntrinsicType::ptr_math), ctx, result));
+        params.push_back(std::make_shared<BoundIdentifier>(Token {}, "ptr", lhs->type()));
+        params.push_back(std::make_shared<BoundIdentifier>(Token {}, "offset", ObjectType::get("s32")));
+        auto decl = std::make_shared<BoundIntrinsicDecl>("/", ident, params);
+        return TRY(process(std::make_shared<BoundIntrinsicCall>(expr->token(), decl, BoundExpressions { lhs, offset }, IntrinsicType::ptr_math), ctx, result));
     }
 
     if ((rhs->node_type() == SyntaxNodeType::BoundIntLiteral) && (rhs->type()->type() == lhs->type()->type()) && (rhs->type()->size() > lhs->type()->size()))
@@ -98,7 +98,7 @@ NODE_PROCESSOR(BoundBinaryExpression)
     if (!impl.is_intrinsic || impl.intrinsic == IntrinsicType::NotIntrinsic)
         return SyntaxError { ErrorCode::InternalError, lhs->token(), format("No intrinsic defined for {}", method_descr.name()) };
     auto intrinsic = impl.intrinsic;
-    return TRY(process(make_node<BoundIntrinsicCall>(expr->token(), method_descr.declaration(), BoundExpressions { lhs, rhs }, intrinsic), ctx));
+    return TRY(process(std::make_shared<BoundIntrinsicCall>(expr->token(), method_descr.declaration(), BoundExpressions { lhs, rhs }, intrinsic), ctx));
 }
 
 ProcessResult resolve_operators(std::shared_ptr<SyntaxNode> const& tree)

--- a/src/obelix/bind/BindTypes.cpp
+++ b/src/obelix/bind/BindTypes.cpp
@@ -416,13 +416,13 @@ NODE_PROCESSOR(FunctionDecl)
     std::shared_ptr<BoundFunctionDecl> bound_decl;
     switch (decl->node_type()) {
     case SyntaxNodeType::IntrinsicDecl:
-        bound_decl = std::make_shared<BoundIntrinsicDecl>(std::dynamic_pointer_cast<IntrinsicDecl>(decl), identifier, bound_parameters);
+        bound_decl = std::make_shared<BoundIntrinsicDecl>(std::dynamic_pointer_cast<IntrinsicDecl>(decl), decl->module(), identifier, bound_parameters);
         break;
     case SyntaxNodeType::NativeFunctionDecl:
-        bound_decl = std::make_shared<BoundNativeFunctionDecl>(std::dynamic_pointer_cast<NativeFunctionDecl>(decl), identifier, bound_parameters);
+        bound_decl = std::make_shared<BoundNativeFunctionDecl>(std::dynamic_pointer_cast<NativeFunctionDecl>(decl), decl->module(), identifier, bound_parameters);
         break;
     default:
-        bound_decl = std::make_shared<BoundFunctionDecl>(decl, identifier, bound_parameters);
+        bound_decl = std::make_shared<BoundFunctionDecl>(decl, decl->module(), identifier, bound_parameters);
         break;
     }
     ctx.add_declared_function(bound_decl->name(), bound_decl);

--- a/src/obelix/boundsyntax/Function.cpp
+++ b/src/obelix/boundsyntax/Function.cpp
@@ -12,8 +12,9 @@ extern_logging_category(parser);
 
 // -- BoundFunctionDecl -----------------------------------------------------
 
-BoundFunctionDecl::BoundFunctionDecl(std::shared_ptr<SyntaxNode> const& decl, std::shared_ptr<BoundIdentifier> identifier, BoundIdentifiers parameters)
+BoundFunctionDecl::BoundFunctionDecl(std::shared_ptr<SyntaxNode> const& decl, std::string module, std::shared_ptr<BoundIdentifier> identifier, BoundIdentifiers parameters)
     : BoundStatement(decl->token())
+    , m_module(std::move(module))
     , m_identifier(std::move(identifier))
     , m_parameters(std::move(parameters))
 {
@@ -21,16 +22,23 @@ BoundFunctionDecl::BoundFunctionDecl(std::shared_ptr<SyntaxNode> const& decl, st
 
 BoundFunctionDecl::BoundFunctionDecl(std::shared_ptr<BoundFunctionDecl> const& decl)
     : BoundStatement(decl->token())
+    , m_module(decl->module())
     , m_identifier(decl->identifier())
     , m_parameters(decl->parameters())
 {
 }
 
-BoundFunctionDecl::BoundFunctionDecl(std::shared_ptr<BoundIdentifier> identifier, BoundIdentifiers parameters)
+BoundFunctionDecl::BoundFunctionDecl(std::string module, std::shared_ptr<BoundIdentifier> identifier, BoundIdentifiers parameters)
     : BoundStatement(Token {})
+    , m_module(std::move(module))
     , m_identifier(std::move(identifier))
     , m_parameters(std::move(parameters))
 {
+}
+
+std::string const& BoundFunctionDecl::module() const
+{
+    return m_module;
 }
 
 std::shared_ptr<BoundIdentifier> const& BoundFunctionDecl::identifier() const
@@ -101,14 +109,14 @@ std::string BoundFunctionDecl::parameters_to_string() const
 
 // -- BoundNativeFunctionDecl -----------------------------------------------
 
-BoundNativeFunctionDecl::BoundNativeFunctionDecl(std::shared_ptr<NativeFunctionDecl> const& decl, std::shared_ptr<BoundIdentifier> identifier, BoundIdentifiers parameters)
-    : BoundFunctionDecl(decl, std::move(identifier), std::move(parameters))
+BoundNativeFunctionDecl::BoundNativeFunctionDecl(std::shared_ptr<NativeFunctionDecl> const& decl, std::string module, std::shared_ptr<BoundIdentifier> identifier, BoundIdentifiers parameters)
+    : BoundFunctionDecl(decl, std::move(module), std::move(identifier), std::move(parameters))
     , m_native_function_name(decl->native_function_name())
 {
 }
 
-BoundNativeFunctionDecl::BoundNativeFunctionDecl(std::shared_ptr<BoundNativeFunctionDecl> const& decl, std::shared_ptr<BoundIdentifier> identifier, BoundIdentifiers parameters)
-    : BoundFunctionDecl(decl, std::move(identifier), std::move(parameters))
+BoundNativeFunctionDecl::BoundNativeFunctionDecl(std::shared_ptr<BoundNativeFunctionDecl> const& decl, std::string module, std::shared_ptr<BoundIdentifier> identifier, BoundIdentifiers parameters)
+    : BoundFunctionDecl(decl, std::move(module), std::move(identifier), std::move(parameters))
     , m_native_function_name(decl->native_function_name())
 {
 }
@@ -130,13 +138,13 @@ std::string BoundNativeFunctionDecl::to_string() const
 
 // -- BoundIntrinsicDecl ----------------------------------------------------
 
-BoundIntrinsicDecl::BoundIntrinsicDecl(std::shared_ptr<SyntaxNode> const& decl, std::shared_ptr<BoundIdentifier> identifier, BoundIdentifiers parameters)
-    : BoundFunctionDecl(decl, std::move(identifier), std::move(parameters))
+BoundIntrinsicDecl::BoundIntrinsicDecl(std::shared_ptr<SyntaxNode> const& decl, std::string module, std::shared_ptr<BoundIdentifier> identifier, BoundIdentifiers parameters)
+    : BoundFunctionDecl(decl, std::move(module), std::move(identifier), std::move(parameters))
 {
 }
 
-BoundIntrinsicDecl::BoundIntrinsicDecl(std::shared_ptr<BoundIdentifier> identifier, BoundIdentifiers parameters)
-    : BoundFunctionDecl(std::move(identifier), std::move(parameters))
+BoundIntrinsicDecl::BoundIntrinsicDecl(std::string module, std::shared_ptr<BoundIdentifier> identifier, BoundIdentifiers parameters)
+    : BoundFunctionDecl(std::move(module), std::move(identifier), std::move(parameters))
 {
 }
 

--- a/src/obelix/boundsyntax/Function.h
+++ b/src/obelix/boundsyntax/Function.h
@@ -15,8 +15,9 @@ namespace Obelix {
 
 NODE_CLASS(BoundFunctionDecl, BoundStatement)
 public:
-    BoundFunctionDecl(std::shared_ptr<SyntaxNode> const&, std::shared_ptr<BoundIdentifier>, BoundIdentifiers);
+    BoundFunctionDecl(std::shared_ptr<SyntaxNode> const&, std::string, std::shared_ptr<BoundIdentifier>, BoundIdentifiers);
     BoundFunctionDecl(std::shared_ptr<BoundFunctionDecl> const&);
+    [[nodiscard]] std::string const& module() const;
     [[nodiscard]] std::shared_ptr<BoundIdentifier> const& identifier() const;
     [[nodiscard]] std::string const& name() const;
     [[nodiscard]] std::shared_ptr<ObjectType> type() const;
@@ -28,10 +29,11 @@ public:
     [[nodiscard]] std::string to_string() const override;
 
 protected:
-    explicit BoundFunctionDecl(std::shared_ptr<BoundIdentifier>, BoundIdentifiers);
+    explicit BoundFunctionDecl(std::string, std::shared_ptr<BoundIdentifier>, BoundIdentifiers);
     [[nodiscard]] std::string parameters_to_string() const;
 
 private:
+    std::string m_module;
     std::shared_ptr<BoundIdentifier> m_identifier;
     BoundIdentifiers m_parameters;
 };
@@ -40,8 +42,8 @@ using BoundFunctionDecls = std::vector<std::shared_ptr<BoundFunctionDecl>>;
 
 NODE_CLASS(BoundNativeFunctionDecl, BoundFunctionDecl)
 public:
-    BoundNativeFunctionDecl(std::shared_ptr<NativeFunctionDecl> const&, std::shared_ptr<BoundIdentifier>, BoundIdentifiers);
-    BoundNativeFunctionDecl(std::shared_ptr<BoundNativeFunctionDecl> const&, std::shared_ptr<BoundIdentifier>, BoundIdentifiers);
+    BoundNativeFunctionDecl(std::shared_ptr<NativeFunctionDecl> const&, std::string, std::shared_ptr<BoundIdentifier>, BoundIdentifiers);
+    BoundNativeFunctionDecl(std::shared_ptr<BoundNativeFunctionDecl> const&, std::string, std::shared_ptr<BoundIdentifier>, BoundIdentifiers);
     [[nodiscard]] std::string const& native_function_name() const;
     [[nodiscard]] std::string attributes() const override;
     [[nodiscard]] std::string to_string() const override;
@@ -52,8 +54,8 @@ private:
 
 NODE_CLASS(BoundIntrinsicDecl, BoundFunctionDecl)
 public:
-    BoundIntrinsicDecl(std::shared_ptr<SyntaxNode> const&, std::shared_ptr<BoundIdentifier>, BoundIdentifiers);
-    BoundIntrinsicDecl(std::shared_ptr<BoundIdentifier>, BoundIdentifiers);
+    BoundIntrinsicDecl(std::shared_ptr<SyntaxNode> const&, std::string, std::shared_ptr<BoundIdentifier>, BoundIdentifiers);
+    BoundIntrinsicDecl(std::string, std::shared_ptr<BoundIdentifier>, BoundIdentifiers);
     explicit BoundIntrinsicDecl(std::shared_ptr<BoundFunctionDecl> const&);
     [[nodiscard]] std::string to_string() const override;
 };

--- a/src/obelix/parser/Parser.cpp
+++ b/src/obelix/parser/Parser.cpp
@@ -267,14 +267,14 @@ std::shared_ptr<Statement> Parser::parse_function_definition(Token const& func_t
     if (current_code() == KeywordLink) {
         lex();
         if (auto link_target_maybe = match(TokenCode::DoubleQuotedString, "after '->'"); link_target_maybe.has_value()) {
-            return std::make_shared<NativeFunctionDecl>(name, func_ident, params, link_target_maybe.value().value());
+            return std::make_shared<NativeFunctionDecl>(name, m_current_module, func_ident, params, link_target_maybe.value().value());
         }
         return nullptr;
     }
     if (func_token.code() == KeywordIntrinsic) {
-        return std::make_shared<IntrinsicDecl>(name, func_ident, params);
+        return std::make_shared<IntrinsicDecl>(name, m_current_module, func_ident, params);
     }
-    func_decl = std::make_shared<FunctionDecl>(name, func_ident, params);
+    func_decl = std::make_shared<FunctionDecl>(name, m_current_module, func_ident, params);
     auto stmt = parse_statement();
     if (stmt == nullptr)
         return nullptr;

--- a/src/obelix/syntax/Function.cpp
+++ b/src/obelix/syntax/Function.cpp
@@ -12,11 +12,17 @@ extern_logging_category(parser);
 
 // -- FunctionDecl ----------------------------------------------------------
 
-FunctionDecl::FunctionDecl(Token token, std::shared_ptr<Identifier> identifier, Identifiers parameters)
+FunctionDecl::FunctionDecl(Token token, std::string module, std::shared_ptr<Identifier> identifier, Identifiers parameters)
     : Statement(std::move(token))
+    , m_module(std::move(module))
     , m_identifier(std::move(identifier))
     , m_parameters(std::move(parameters))
 {
+}
+
+std::string const& FunctionDecl::module() const
+{
+    return m_module;
 }
 
 std::shared_ptr<Identifier> const& FunctionDecl::identifier() const
@@ -87,8 +93,8 @@ std::string FunctionDecl::parameters_to_string() const
 
 // -- NativeFunctionDecl ----------------------------------------------------
 
-NativeFunctionDecl::NativeFunctionDecl(Token token, std::shared_ptr<Identifier> identifier, Identifiers parameters, std::string native_function)
-    : FunctionDecl(std::move(token), std::move(identifier), std::move(parameters))
+NativeFunctionDecl::NativeFunctionDecl(Token token, std::string module, std::shared_ptr<Identifier> identifier, Identifiers parameters, std::string native_function)
+    : FunctionDecl(std::move(token), std::move(module), std::move(identifier), std::move(parameters))
     , m_native_function_name(std::move(native_function))
 {
 }
@@ -110,8 +116,8 @@ std::string NativeFunctionDecl::to_string() const
 
 // -- IntrinsicDecl ---------------------------------------------------------
 
-IntrinsicDecl::IntrinsicDecl(Token token, std::shared_ptr<Identifier> identifier, Identifiers parameters)
-    : FunctionDecl(std::move(token), std::move(identifier), std::move(parameters))
+IntrinsicDecl::IntrinsicDecl(Token token, std::string module, std::shared_ptr<Identifier> identifier, Identifiers parameters)
+    : FunctionDecl(std::move(token), std::move(module), std::move(identifier), std::move(parameters))
 {
 }
 

--- a/src/obelix/syntax/Function.h
+++ b/src/obelix/syntax/Function.h
@@ -15,8 +15,9 @@ namespace Obelix {
 
 NODE_CLASS(FunctionDecl, Statement)
 public:
-    FunctionDecl(Token, std::shared_ptr<Identifier>, Identifiers);
+    FunctionDecl(Token, std::string, std::shared_ptr<Identifier>, Identifiers);
     [[nodiscard]] std::shared_ptr<Identifier> const& identifier() const;
+    [[nodiscard]] std::string const& module() const;
     [[nodiscard]] std::string const& name() const;
     [[nodiscard]] std::shared_ptr<ExpressionType> type() const;
     [[nodiscard]] std::string type_name() const;
@@ -30,13 +31,14 @@ protected:
     [[nodiscard]] std::string parameters_to_string() const;
 
 private:
+    std::string m_module;
     std::shared_ptr<Identifier> m_identifier;
     Identifiers m_parameters;
 };
 
 NODE_CLASS(NativeFunctionDecl, FunctionDecl)
 public:
-    NativeFunctionDecl(Token, std::shared_ptr<Identifier>, Identifiers, std::string);
+    NativeFunctionDecl(Token, std::string, std::shared_ptr<Identifier>, Identifiers, std::string);
     [[nodiscard]] std::string const& native_function_name() const;
     [[nodiscard]] std::string attributes() const override;
     [[nodiscard]] std::string to_string() const override;
@@ -47,7 +49,7 @@ private:
 
 NODE_CLASS(IntrinsicDecl, FunctionDecl)
 public:
-    IntrinsicDecl(Token, std::shared_ptr<Identifier>, Identifiers);
+    IntrinsicDecl(Token, std::string, std::shared_ptr<Identifier>, Identifiers);
     [[nodiscard]] std::string to_string() const override;
 };
 

--- a/src/obelix/type/MethodDescription.cpp
+++ b/src/obelix/type/MethodDescription.cpp
@@ -142,7 +142,7 @@ std::shared_ptr<BoundIntrinsicDecl> MethodDescription::declaration() const
     for (auto const& p : parameters()) {
         params.push_back(make_node<BoundIdentifier>(Token {}, p.name, p.type));
     }
-    return make_node<BoundIntrinsicDecl>(ident, params);
+    return make_node<BoundIntrinsicDecl>("/", ident, params);
 }
 
 

--- a/test/func.obl
+++ b/test/func.obl
@@ -5,7 +5,7 @@ func f(p1: s32, p2: s32) : s32
 
 func main() : s32
 {
-    puti(f(1s32, 2s32))
-    putln("")
+    puti(f(1, 2))
+    putln()
     return 0
 }


### PR DESCRIPTION
By leaving the name of the function 'bare', it becomes impossible to have two identically named
functions. 
